### PR TITLE
Verwijder verwijzingen naar Rijks ICT Gilde en Dev.loer, voeg Digilab toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 # Het Digi Handboek
 
-Met het Digi Handboek maken we collega's graag wegwijs binnen het Digi Gilde (onderdeel van het
-[Rijks ICT Gilde](https://rijksictgilde.nl/)). Op deze plek kun je onder andere tips en tricks vinden over het opzetten
+Met het Digi Handboek maken we collega's graag wegwijs binnen het Digi Gilde (onderdeel van
+[ODI](https://www.rijksorganisatieodi.nl/)). Op deze plek kun je onder andere tips en tricks vinden over het opzetten
 van een digitale werkplek, hoe we werken en hoe we elkaar kunnen versterken.
 
 In deze repository ontwikkelen wij het Digi Handboek. We werken dit met elkaar uit in verschillende Markdown bestanden

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,8 @@ RIG Gids en informatie op het Rijksportaal.
 
 Wij zijn onderdeel van [ODI](https://www.rijksorganisatieodi.nl/). Met onze groep leveren we een bijdrage
 aan een moderne en transparante digitale overheid. Wij werken onder andere aan de uitvoering van de
-[Nederlandse Digitaliseringsstrategie (NDS)](https://www.digitaleoverheid.nl/nederlandse-digitaliseringsstrategie-nds/).
+[Nederlandse Digitaliseringsstrategie (NDS)](https://www.digitaleoverheid.nl/nederlandse-digitaliseringsstrategie-nds/)
+en we bemensen de Nederlandse Digitale Dienst.
 
 Het Digi Gilde ontwikkelt open source softwareproducten en prototypes voor de overheid van nu en morgen. Daarbij zorgen
 wij voor een generieke digitale basis door middel van platform engineering. Dit betekent dat we ook interne tools en

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,10 @@ De eerste stappen hebben we hiervoor al gezet. Zo werken we nu bijvoorbeeld aan 
 - **[RegelRecht](https://regelrecht.rijks.app/)** verkent of wetgeving als uitvoerbare code geschreven kan worden,
   zodat verschillende organisaties dezelfde wet ook hetzelfde toepassen en burgers kunnen volgen hoe een besluit tot
   stand komt.
+- **[Digilab](https://digilab.overheid.nl/)** is een broedplaats voor de vernieuwing van de digitale overheid, waar
+  overheidsprofessionals van gemeenten tot ministeries samenwerken aan gedeelde vraagstukken rond interoperabiliteit,
+  vertrouwen en datagovernance. Digilab biedt een soevereine infrastructuur om prototypes te ontwikkelen, los van
+  bestaande institutionele kaders.
 
 Het Digi Gilde is enthousiast en met toewijding bezig om samen met beleidsmakers, juristen, bestuurders en andere
 experts een succes te maken van bovenstaande projecten. En wij hebben er zin in om meer projecten op te gaan pakken

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 # Het Digi Handboek
 
 Welkom bij het Digi Handboek! Hier vind je alle informatie die je nodig hebt om goed te starten bij het Digi Gilde
-(onderdeel van het [Rijks ICT Gilde](https://rijksictgilde.nl)).
+(onderdeel van [ODI](https://www.rijksorganisatieodi.nl/)).
 
 In dit handboek vind je:
 
@@ -19,7 +19,7 @@ RIG Gids en informatie op het Rijksportaal.
 
 ## Over het Digi Gilde
 
-Wij zijn onderdeel van het [Rijks ICT Gilde](https://rijksictgilde.nl). Met onze groep leveren we een bijdrage
+Wij zijn onderdeel van [ODI](https://www.rijksorganisatieodi.nl/). Met onze groep leveren we een bijdrage
 aan een moderne en transparante digitale overheid. Wij werken onder andere aan de uitvoering van de
 [Nederlandse Digitaliseringsstrategie (NDS)](https://www.digitaleoverheid.nl/nederlandse-digitaliseringsstrategie-nds/).
 
@@ -53,7 +53,7 @@ softwareproducten kan worden doorontwikkeld. Daarom hebben we aanvullend platfor
 van het Digi Gilde. Dit is namelijk een onderdeel van wat nodig is om een goede ontwikkelervaring (DevEx, ofwel
 Developer Experience) te kunnen bieden.
 
-Het maken en beheren van softwareproducten is niet nieuw voor het Rijks ICT Gilde. Met het Digi Gilde willen we dit
+Het maken en beheren van softwareproducten is niet nieuw voor ODI. Met het Digi Gilde willen we dit
 specifiek op de kaart zetten en de krachten bundelen. We willen een omgeving bieden met een DevEx die ontwikkelingen
 versnelt. Wat daarbij wel nieuw is, is dat we nu uitspreken dat we in de toekomst beheer willen doen van de door ons
 ontwikkelde softwareproducten. Stap voor stap gaan we hier mee aan de slag.

--- a/docs/offboarding.md
+++ b/docs/offboarding.md
@@ -10,9 +10,8 @@ We vinden het jammer om je te zien gaan! Maar als je dat dan doet, is dit wat je
 ## GitHub
 
 - Zorg ervoor dat je eventueel eigenaarschap overdraagt aan het team.
-- Zorg ervoor dat je de [Digi Gilde](https://github.com/orgs/DigiGilde/people/) en
-  [Rijks ICT Gilde](https://github.com/orgs/RijksICTGilde/people/) organisatie en eventueel relevante teams verlaat op
-  GitHub.
+- Zorg ervoor dat je de [Digi Gilde](https://github.com/orgs/DigiGilde/people/) organisatie en eventueel relevante teams
+  verlaat op GitHub.
 - Als je de overheid helemaal verlaat, zorg er dan voor dat je je ook verwijdert uit de
   [MinBZK](https://github.com/orgs/MinBZK) organisatie.
 

--- a/docs/onboarding/accounts.md
+++ b/docs/onboarding/accounts.md
@@ -13,7 +13,7 @@ Zorg ervoor dat je [Mattermost](dev-machine.md#communicatie) hebt geïnstalleerd
         https://digilab.overheid.nl/chat
         ```
 
-3. Vraag een collega om je toe te voegen aan het Digi Gilde en Rijks ICT Gilde team.
+3. Vraag een collega om je toe te voegen aan het Digi Gilde team.
 4. Vergeet niet om even je profiel in te stellen inclusief een herkenbare profiel afbeelding.
 
 ## Webex
@@ -37,8 +37,7 @@ GitHub, betekent niet dat je een account hoeft te gebruiken die naar jou als pri
 probleem om een anoniem account aan te maken. Als je een account hebt, volg daarna de volgende stappen:
 
 - Voeg je `@rijksoverheid.nl` e-mailadres toe aan je account.
-- Vraag een collega om je toe te voegen aan de GitHub organisatie [Digi Gilde](https://github.com/orgs/DigiGilde) en
-  [Rijks ICT Gilde](https://github.com/orgs/RijksICTGilde).
+- Vraag een collega om je toe te voegen aan de GitHub organisatie [Digi Gilde](https://github.com/orgs/DigiGilde).
 - Vraag een collega om je toe te voegen aan de GitHub organisatie [MinBZK](https://github.com/orgs/MinBZK).
 
 ## Deel je Outlook agenda

--- a/docs/onboarding/hybride-werken.md
+++ b/docs/onboarding/hybride-werken.md
@@ -50,29 +50,8 @@ HSD is een locatie waar ODI een kantoor- en vergaderruimte heeft. Wil je daar we
 via [RIG@rijksoverheid.nl](mailto:RIG@rijksoverheid.nl) regelen. Bij HSD hebben we ook de mogelijkheden om extra
 vergaderruimtes te huren.
 
-### Digilab (Dev.loer)
-
-> Dev.loer / Digilab  
-> Gebouw Trindeborch, 5e verdieping
-> Catharijnesingel 55  
-> 3511 GD Utrecht
-
-[Digilab](https://digilab.overheid.nl/) is een broedplaats voor technische innovaties, bedoeld voor projecten die voor
-of met de overheid werken. Zij hebben ook de Dev.loer. Dev.loer biedt jou een flexwerkplek met koffie, wifi en
-breedbeeldschermen waar je samen kunt werken.
-
-Wil je daar een dag werken, vraag dan een van je collega's voor toegang tot het deurkanaal op het Digilab team op
-Mattermost. Ook kun je via het Digilab team op Mattermost een werkplek of vergaderruimte reserveren via de reservation
-bot.
-
-Praktische zaken:
-
-- Code deur beneden staat in de beschrijving het [deur kanaal](https://digilab.overheid.nl/chat/digilab/channels/deur)
-- Deur boven openen doe je door een verzoek aan de `Door Lock Bot` (zie
-  [deur kanaal](https://digilab.overheid.nl/chat/digilab/channels/deur)). Hiermee open je de deur aan de linkerkant. De
-  deur die bij de liften zit.
-- Vergaderruimte of werkplek reserveren gaat via de `reservation bot` (zie
-  [reserveringen kanaal](https://digilab.overheid.nl/chat/digilab/channels/reserveringen))
+Een werkplek of vergaderruimte reserveer je via de `reservation bot` op Mattermost (zie de
+[Reservation Bot](../kennis/reservation-bot.md) uitleg).
 
 ### Rijkshub
 

--- a/docs/onboarding/hybride-werken.md
+++ b/docs/onboarding/hybride-werken.md
@@ -46,7 +46,7 @@ Een werkplek reserveren is niet verplicht, maar wel mogelijk. Een werkplek op Be
 > Wilhelmina van Pruisenweg 104  
 > 2595 AN Den Haag
 
-HSD is een locatie waar het Rijks ICT Gilde een kantoor- en vergaderruimte heeft. Wil je daar werken, dan kun je dat
+HSD is een locatie waar ODI een kantoor- en vergaderruimte heeft. Wil je daar werken, dan kun je dat
 via [RIG@rijksoverheid.nl](mailto:RIG@rijksoverheid.nl) regelen. Bij HSD hebben we ook de mogelijkheden om extra
 vergaderruimtes te huren.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,9 +63,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/DigiGilde/
     - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/company/rijksictgilde/
+      link: https://www.linkedin.com/company/rijksorganisatie-odi/
     - icon: fontawesome/solid/globe
-      link: https://rijksictgilde.nl/
+      link: https://www.rijksorganisatieodi.nl/
 
 extra_templates:
   - .well-known/security.txt


### PR DESCRIPTION
## Samenvatting
- Alle tekstuele en link-verwijzingen naar het Rijks ICT Gilde vervangen door ODI (Rijksorganisatie ODI)
- GitHub-organisatieverwijzing naar `RijksICTGilde` verwijderd uit offboarding en accounts
- Social links in `mkdocs.yml` (website, LinkedIn) bijgewerkt naar de officiële ODI-kanalen
- Dev.loer/Digilab locatie verwijderd (bestaat niet meer); de reservering via de Mattermost reservation bot is verplaatst naar de HSD-sectie
- Digilab toegevoegd aan de voorbeeldprojecten op de homepage

## Test plan
- [ ] `mkdocs serve` lokaal draaien en controleren dat de homepage, offboarding, accounts en hybride-werken pagina's correct renderen
- [ ] Links naar rijksorganisatieodi.nl en LinkedIn handmatig controleren
- [ ] Reservation Bot link in de HSD-sectie controleren
- [ ] Digilab-project op de homepage controleren